### PR TITLE
Add Model Training Section

### DIFF
--- a/fragments/training/README.md
+++ b/fragments/training/README.md
@@ -1,3 +1,10 @@
 # Model Training Fragment
 
-**THIS SECTION IS STILL UNDER DEVELOPMENT**
+The Model Training fragment captures essential information about how the model was trained, including the 
+compute environment, training datasets, and the date on which the model was trained. The goal of this section 
+is to capture enough information that a new developer could reasonably reproduce the trained model. This also 
+contributes to the ability to reproduce published model results.
+
+## Directory Contents
+
+* [`training-fragment.md`](./training-fragment.md) - The detailed Model Training Fragment Specification.

--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -43,8 +43,8 @@ The STAC [Label Extension] is intended to support the use of labeled AOIs with m
 the use of both raster labels and vector labels. The extension supports labels for the following machine learning model 
 types:
 
-* Tile classification
-* Tile regression
+* Classification
+* Regression
 * Object detection
 * Segmentation
 

--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -5,25 +5,45 @@ This document describes the structure and content of a Model Training object.
 | Field Name          | Type                | Description                                                           |
 |---------------------|---------------------|-----------------------------------------------------------------------|
 | `created_at`        | string              | **Required.** Approximate date and time at which the model was trained. It is formatted according to [RFC 3339, section 5.6].  |
-| `environment`       | [Environment]       | **Required.** Description of the environment used to train the model.               |
-| `input_data`        | [string]            | **Required.** A list of URLs, each of which points to a [STAC Collection] representing input data used to train the model. |
+| `environment`       | [Environment]       | **Required.** Description of the environment used to train the model. |
+| `source_imagery`    | [string]            | **Required.** A list of URLs, each of which points to a [STAC Collection] representing source imagery used to train the model. |
 | `labels`            | [string]            | A list of URLs, each of which points to a [STAC Collection] representing labels used to train the model. This is only applicable to supervised models and should be omitted for all unsupervised models. |
 
 #### created_at
 
-This field is intended to capture the approximate date and time at which the model was trained in order to give other developers a sense of the currency of 
-the model. The model publisher is free to choose the exact event that this timestamp represents (e.g. start of model training, completion of model training, etc.). Publishers 
-may also choose to use `00` for all time values if they wish to only represent a date (e.g. `2020-02-01T00:00:00Z`).
+This field is intended to capture the approximate date and time at which the model was trained in order to give 
+other developers a sense of the currency of the model. The model publisher is free to choose the exact event that 
+this timestamp represents (e.g. start of model training, completion of model training, etc.). Publishers may also 
+choose to use `00` for all time values if they wish to only represent a date (e.g. `2020-02-01T00:00:00Z`).
 
-#### input_data
+#### source_imagery
 
-This field will be a list of URLs, each of which points to a [STAC Collection] representing input data used to train the model. This will most typically be a Collection of source images, and should implement any [STAC Extensions] required to thoroughly describe the source data. For instance, a collection of optical satellite imagery should probably implement 
-the [Projection], [View Geometry], and [Electro-Optical] extensions.
+This field will be a list of URLs, each of which points to a [STAC Collection] representing input data used to train 
+the model. This will most typically be a Collection of source images, and should implement any [STAC Extensions] 
+required to thoroughly describe the source data. For instance, a collection of optical satellite imagery should probably 
+implement the [Projection], [View Geometry], and [Electro-Optical] extensions.
 
 #### labels
 
-This field will be a list of URLs, each of which points to a [STAC Collection] representing labels used to train the model. At a minimum, the Collection should implement the 
-[Label] extension. The Collection should also implement any other [STAC Extensions] required to thoroughly describe the label dataset.
+This field will be a list of URLs, each of which points to a [STAC Collection] representing labels used to train the 
+model. The Collection must implement the [Label] extension and should also implement any other [STAC Extensions] 
+that the model publisher believes are necessary to thoroughly describe the dataset.
+
+The STAC [Label] extension is intended to support the use of labeled AOIs with machine learning models and supports 
+the use of both raster labels and vector labels. The extension supports labels for the following machine learning model 
+types:
+
+* Tile classification
+* Tile regression
+* Object detection
+* Segmentation
+
+Model publishers are encouraged to review the [Label] extension in detail to better understand its capabilities and how
+to use it to properly catalog training data. *The extension is still in the "Proposal" stage and is undergoing active 
+development.* Model publishers are encouraged to contribute to the development of that specification to ensure that it 
+meets the needs of the community. See the "Get Involved" section of the [STAC Spec site] for details on how to join the 
+discussion.
+
 
 [RFC 3339, section 5.6]: https://tools.ietf.org/html/rfc3339#section-5.6
 [STAC Collection]: https://github.com/radiantearth/stac-spec/tree/master/collection-spec
@@ -33,3 +53,5 @@ This field will be a list of URLs, each of which points to a [STAC Collection] r
 [View Geometry]: https://github.com/stac-extensions/view
 [Electro-Optical]: https://github.com/stac-extensions/eo
 [Label]: https://github.com/stac-extensions/label
+[Input Datasets]: #input-datasets
+[STAC Spec site]: https://stacspec.org/

--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -13,7 +13,9 @@ This document describes the structure and content of a Model Training object.
 This field is intended to capture the approximate date and time at which the model was trained in order to give 
 other developers a sense of the currency of the model. The model publisher is free to choose the exact event that 
 this timestamp represents (e.g. start of model training, completion of model training, etc.). Publishers may also 
-choose to use `00` for all time values if they wish to only represent a date (e.g. `2020-02-01T00:00:00Z`).
+choose to use `00` for all time values if they wish to only represent a date (e.g.
+`2020-02-01T00:00:00Z`). This format keeps the spec in line the datetime format requirements from
+the STAC spec.
 
 #### data
 

--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -20,10 +20,12 @@ the STAC spec.
 #### data
 
 A list of URLs, each of which points to a [STAC Collection] representing input data used to train
-the model. The Collection must implement the [ML AOI Extension], which describes how individual
-Items are split into `train`, `test`, and `validation` sets. As per the ML AOI Extension, Items 
-in the Collection will then link to Items describing the input data itself, as well as labels (for 
-supervised learning models). 
+the model. The link may reference a hosted static Collection or a Collection that is part of a
+[STAC API] implementation. If the Collection is part of a STAC API implementation, then the
+`/collections/{collection_id}` endpoint should be used. Collections must implement the [ML AOI
+Extension], which describes how individual Items are split into `train`, `test`, and `validation`
+sets. As per the ML AOI Extension, Items in the Collection will then link to Items describing the 
+input data itself, as well as labels (for supervised learning models). 
 
 ##### Input Data
 
@@ -66,3 +68,4 @@ discussion.
 [Input Datasets]: #input-datasets
 [STAC Spec site]: https://stacspec.org/
 [ML AOI Extension]: https://github.com/azavea/stac-ml-aoi-extension/tree/master/ml-aoi
+[STAC API]: https://github.com/radiantearth/stac-api-spec

--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -1,6 +1,35 @@
 # Model Training Fragment
 
-**THIS SECTION IS STILL UNDER DEVELOPMENT.**
+This document describes the structure and content of a Model Training object.
 
 | Field Name          | Type                | Description                                                           |
 |---------------------|---------------------|-----------------------------------------------------------------------|
+| `created_at`        | string              | **Required.** Approximate date and time at which the model was trained. It is formatted according to [RFC 3339, section 5.6].  |
+| `environment`       | [Environment]       | **Required.** Description of the environment used to train the model.               |
+| `input_data`        | [string]            | **Required.** A list of URLs, each of which points to a [STAC Collection] representing input data used to train the model. |
+| `labels`            | [string]            | A list of URLs, each of which points to a [STAC Collection] representing labels used to train the model. This is only applicable to supervised models and should be omitted for all unsupervised models. |
+
+#### created_at
+
+This field is intended to capture the approximate date and time at which the model was trained in order to give other developers a sense of the currency of 
+the model. The model publisher is free to choose the exact event that this timestamp represents (e.g. start of model training, completion of model training, etc.). Publishers 
+may also choose to use `00` for all time values if they wish to only represent a date (e.g. `2020-02-01T00:00:00Z`).
+
+#### input_data
+
+This field will be a list of URLs, each of which points to a [STAC Collection] representing input data used to train the model. This will most typically be a Collection of source images, and should implement any [STAC Extensions] required to thoroughly describe the source data. For instance, a collection of optical satellite imagery should probably implement 
+the [Projection], [View Geometry], and [Electro-Optical] extensions.
+
+#### labels
+
+This field will be a list of URLs, each of which points to a [STAC Collection] representing labels used to train the model. At a minimum, the Collection should implement the 
+[Label] extension. The Collection should also implement any other [STAC Extensions] required to thoroughly describe the label dataset.
+
+[RFC 3339, section 5.6]: https://tools.ietf.org/html/rfc3339#section-5.6
+[STAC Collection]: https://github.com/radiantearth/stac-spec/tree/master/collection-spec
+[Environment]: ../environment/environment-fragment.md
+[STAC Extensions]: https://stac-extensions.github.io/
+[Projection]: https://github.com/stac-extensions/projection
+[View Geometry]: https://github.com/stac-extensions/view
+[Electro-Optical]: https://github.com/stac-extensions/eo
+[Label]: https://github.com/stac-extensions/label

--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -6,8 +6,7 @@ This document describes the structure and content of a Model Training object.
 |---------------------|---------------------|-----------------------------------------------------------------------|
 | `created_at`        | string              | **Required.** Approximate date and time at which the model was trained. It is formatted according to [RFC 3339, section 5.6].  |
 | `environment`       | [Environment]       | **Required.** Description of the environment used to train the model. |
-| `source_imagery`    | [string]            | **Required.** A list of URLs, each of which points to a [STAC Collection] representing source imagery used to train the model. |
-| `labels`            | [string]            | A list of URLs, each of which points to a [STAC Collection] representing labels used to train the model. This is only applicable to supervised models and should be omitted for all unsupervised models. |
+| `data`              | [string]            | **Required.** A list of URLs, each of which points to a [STAC Collection] representing source imagery used to train the model. |
 
 #### created_at
 
@@ -16,20 +15,29 @@ other developers a sense of the currency of the model. The model publisher is fr
 this timestamp represents (e.g. start of model training, completion of model training, etc.). Publishers may also 
 choose to use `00` for all time values if they wish to only represent a date (e.g. `2020-02-01T00:00:00Z`).
 
-#### source_imagery
+#### data
 
-This field will be a list of URLs, each of which points to a [STAC Collection] representing input data used to train 
-the model. This will most typically be a Collection of source images, and should implement any [STAC Extensions] 
-required to thoroughly describe the source data. For instance, a collection of optical satellite imagery should probably 
-implement the [Projection], [View Geometry], and [Electro-Optical] extensions.
+A list of URLs, each of which points to a [STAC Collection] representing input data used to train
+the model. The Collection must implement the [ML AOI Extension], which describes how individual
+Items are split into `train`, `test`, and `validation` sets. As per the ML AOI Extension, Items 
+in the Collection will then link to Items describing either source imagery or labels (for 
+supervised learning models). 
 
-#### labels
+##### Source Imagery Data
 
-This field will be a list of URLs, each of which points to a [STAC Collection] representing labels used to train the 
-model. The Collection must implement the [Label] extension and should also implement any other [STAC Extensions] 
-that the model publisher believes are necessary to thoroughly describe the dataset.
+The Collection referred to in the `data` field will in turn reference Items in a source imagery
+Collection. This Collection should implement any [STAC Extensions] required to thoroughly describe 
+the source data. For instance, a collection of optical satellite imagery should probably implement 
+the [Projection], [View Geometry], and [Electro-Optical] extensions.
 
-The STAC [Label] extension is intended to support the use of labeled AOIs with machine learning models and supports 
+##### Label Data
+
+For supervised learning models, the Collection referred to in the `data` field will in turn
+reference Items in a label Collection. Items in this label Collection must implement the [Label 
+Extension] and should also implement any other [STAC Extensions] that the model publisher 
+believes are necessary to thoroughly describe the dataset.
+
+The STAC [Label Extension] is intended to support the use of labeled AOIs with machine learning models and supports 
 the use of both raster labels and vector labels. The extension supports labels for the following machine learning model 
 types:
 
@@ -38,7 +46,7 @@ types:
 * Object detection
 * Segmentation
 
-Model publishers are encouraged to review the [Label] extension in detail to better understand its capabilities and how
+Model publishers are encouraged to review the [Label Extension] in detail to better understand its capabilities and how
 to use it to properly catalog training data. *The extension is still in the "Proposal" stage and is undergoing active 
 development.* Model publishers are encouraged to contribute to the development of that specification to ensure that it 
 meets the needs of the community. See the "Get Involved" section of the [STAC Spec site] for details on how to join the 
@@ -52,6 +60,7 @@ discussion.
 [Projection]: https://github.com/stac-extensions/projection
 [View Geometry]: https://github.com/stac-extensions/view
 [Electro-Optical]: https://github.com/stac-extensions/eo
-[Label]: https://github.com/stac-extensions/label
+[Label Extension]: https://github.com/stac-extensions/label
 [Input Datasets]: #input-datasets
 [STAC Spec site]: https://stacspec.org/
+[ML AOI Extension]: https://github.com/azavea/stac-ml-aoi-extension/tree/master/ml-aoi

--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -6,7 +6,7 @@ This document describes the structure and content of a Model Training object.
 |---------------------|---------------------|-----------------------------------------------------------------------|
 | `created_at`        | string              | **Required.** Approximate date and time at which the model was trained. It is formatted according to [RFC 3339, section 5.6].  |
 | `environment`       | [Environment]       | **Required.** Description of the environment used to train the model. |
-| `data`              | [string]            | **Required.** A list of URLs, each of which points to a [STAC Collection] representing source imagery used to train the model. |
+| `data`              | [string]            | **Required.** A list of URLs, each of which points to a [STAC Collection] representing input data used to train the model. |
 
 #### created_at
 
@@ -22,19 +22,19 @@ the STAC spec.
 A list of URLs, each of which points to a [STAC Collection] representing input data used to train
 the model. The Collection must implement the [ML AOI Extension], which describes how individual
 Items are split into `train`, `test`, and `validation` sets. As per the ML AOI Extension, Items 
-in the Collection will then link to Items describing either source imagery or labels (for 
+in the Collection will then link to Items describing the input data itself, as well as labels (for 
 supervised learning models). 
 
-##### Source Imagery Data
+##### Input Data
 
-The Collection referred to in the `data` field will in turn reference Items in a source imagery
+Items from the Collection linked to in the `data` field will in turn reference Items in an input data
 Collection. This Collection should implement any [STAC Extensions] required to thoroughly describe 
 the source data. For instance, a collection of optical satellite imagery should probably implement 
 the [Projection], [View Geometry], and [Electro-Optical] extensions.
 
 ##### Label Data
 
-For supervised learning models, the Collection referred to in the `data` field will in turn
+For supervised learning models, Items from the Collection linked to in the `data` field will also
 reference Items in a label Collection. Items in this label Collection must implement the [Label 
 Extension] and should also implement any other [STAC Extensions] that the model publisher 
 believes are necessary to thoroughly describe the dataset.

--- a/model-metadata/model-metadata.md
+++ b/model-metadata/model-metadata.md
@@ -35,7 +35,7 @@ This string provides a more specific description of the type of model. It is STR
 following values, but other values are allowed. Note that not all Model Type values are valid for a given [Algorithm Type].
 
 * `"Object Detection"`
-* `"Image Classification"`
+* `"Classification"`
 * `"Segmentation"`
 * `"Regression"`
 

--- a/model-metadata/model-metadata.md
+++ b/model-metadata/model-metadata.md
@@ -38,8 +38,6 @@ following values, but other values are allowed. Note that not all Model Type val
 * `"Image Classification"`
 * `"Segmentation"`
 * `"Regression"`
-* `"Clustering"`
-* `"Dimensionality Reduction"`
 
 ### Author
 

--- a/model-metadata/model-metadata.md
+++ b/model-metadata/model-metadata.md
@@ -7,7 +7,7 @@ This document describes the structure and content of a top-level Model Metadata 
 | Field Name           | Type               | Description                                                                         |
 |----------------------|--------------------|-------------------------------------------------------------------------------------|
 | `model_id`           | string             | **REQUIRED.** A unique string identifier for the model. This ID must be unique across the provider. |
-| `algorithm_type`     | [Algorithm Type]\|string | **REQUIRED.** A string identifying the high-level algorithm type that the model employes. STRONGLY RECOMMENDED to use on the standard [Algorithm Type] values, but other values are allowed. |
+| `algorithm_type`     | [Algorithm Type]\|string | **REQUIRED.** A string identifying the high-level algorithm type that the model employs. STRONGLY RECOMMENDED to use on the standard [Algorithm Type] values, but other values are allowed. |
 | `model_type`         | [Model Type]\|string | **REQUIRED.** Identifier for the type of model. STRONGLY RECOMMENDED to use on of the standard [Model Type] values, but other values are allowed. |
 | `model_architecture` | string             | Identifies the model architecture used (e.g. RCNN, U-Net, etc.).                    |
 | `license`            | string             | **REQUIRED.** The model's license(s). Either a SPDX [License identifier], `various` if multiple licenses apply, or `proprietary` for all other cases. |
@@ -21,8 +21,8 @@ This document describes the structure and content of a top-level Model Metadata 
 
 ### Algorithm Type
 
-This string describes the general type of machine learning algorithm employed by the model. It is STRONGLY RECOMMENDED that you use one of the following values, but 
-other values are allowed.
+This string describes the general type of machine learning algorithm employed by the model. It is STRONGLY RECOMMENDED 
+that you use one of the following values, but other values are allowed.
 
 * `"Supervised"`
 * `"Unsupervised"`
@@ -31,8 +31,8 @@ other values are allowed.
 
 ### Model Type
 
-This string provides a more specific description of the type of model. It is STRONGLY RECOMMENDED that you use one of the following values, but other values are allowed.
-Note that not all Model Type values are valid for a given [Algorithm Type].
+This string provides a more specific description of the type of model. It is STRONGLY RECOMMENDED that you use one of the 
+following values, but other values are allowed. Note that not all Model Type values are valid for a given [Algorithm Type].
 
 * `"Object Detection"`
 * `"Image Classification"`
@@ -53,9 +53,10 @@ This object describes an author involved in creating the model.
 
 ### Citation
 
-This object indicates from which publication the model originates and how the model itself should be cited or referenced. The object 
-mirrors the [STAC Scientific Citation Extension] (without the `sci:` field name prefix); all field descriptions are adapted from 
-that definition. *As per the Scientific Citation Extension spec, at least one field is required.*
+This object indicates from which publication the model originates and how the model itself should be cited or 
+referenced. The object mirrors the [STAC Scientific Citation Extension] (without the `sci:` field name prefix); 
+all field descriptions are adapted from that definition. *As per the Scientific Citation Extension spec, at least 
+one field is required.*
 
 | Field Name     | Type                     | Description                                                               |
 |----------------|--------------------------|---------------------------------------------------------------------------|


### PR DESCRIPTION
Adds the section on Model Training to describe the training data and training environment. This section mostly follows what was discussed in the [original Google Doc](https://docs.google.com/document/d/17vJivyrWVOLc36B9QmO8aVxtqP3cmLAeUgWBgFGHUlg/edit?usp=sharing) with some minor changes to simplify and/or clarify some parts. 

A couple of notes and known issues:

* The STAC Label Extension only explicitly supports datasets for classification, object detection, segmentation, and regression. Our [Model Type section](https://github.com/radiantearth/geo-ml-model-catalog/blob/4563c8b103633c5b00bdb91908de1009b422d942/model-metadata/model-metadata.md#model-type) also mentioned clustering and dimensionality reduction. I removed these since a model publisher would have no way of defining the training dataset within this spec.
* The [`label` section](https://github.com/radiantearth/geo-ml-model-catalog/blob/4563c8b103633c5b00bdb91908de1009b422d942/fragments/training/training-fragment.md#labels) in the new Model Training Fragment references the STAC Label extension. Do we need more description or context within this repo regarding the Label extension or is it enough to link to the extension repo?

Closes #9 