### PR TITLE
Update link to ML AOI Extension

### DIFF
--- a/fragments/training/training-fragment.md
+++ b/fragments/training/training-fragment.md
@@ -67,5 +67,5 @@ discussion.
 [Label Extension]: https://github.com/stac-extensions/label
 [Input Datasets]: #input-datasets
 [STAC Spec site]: https://stacspec.org/
-[ML AOI Extension]: https://github.com/azavea/stac-ml-aoi-extension/tree/master/ml-aoi
+[ML AOI Extension]: https://github.com/stac-extensions/ml-aoi
 [STAC API]: https://github.com/radiantearth/stac-api-spec


### PR DESCRIPTION
The ML AOI Extension has moved into the stac-extensions GitHub org and we are planning on actively developing it there. This PR updates the reference in the Model Training section to point to the new repo.

Since this is a pretty non-controversial change I'm going to merge without review. Feel free to open and issue or comment on this PR after the fact with any concerns.